### PR TITLE
Update 1.0 Download SMAP data.ipynb

### DIFF
--- a/notebooks/1.0 Download SMAP data.ipynb
+++ b/notebooks/1.0 Download SMAP data.ipynb
@@ -17,7 +17,7 @@
     "* SMAP data are available through the following url:\n",
     "    * https://n5eil02u.ecs.nsidc.org/opendap/SMAP/\n",
     "\n",
-    "* For these examples, we will use **SPL3SMP version 004**, but the same methdology to access and subset SMAP data will work for any of the products availabe there"
+    "* For these examples, we will use **SPL3SMP version 009**, but the same methdology to access and subset SMAP data will work for any of the products availabe there"
    ]
   },
   {
@@ -77,13 +77,13 @@
     "def SMAP_L3_P_36km_Path(year, month, day):\n",
     "    fpath_start = 'https://n5eil01u.ecs.nsidc.org/SMAP/'\n",
     "    host = 'https://n5eil01u.ecs.nsidc.org/'\n",
-    "    version = '.004'\n",
+    "    version = '.009'\n",
     "    url_path = '{host}/SMAP/SPL3SMP{version}/{year}.{month:02}.{day:02}/'.format(host=host,\n",
     "                                                                                 version=version,\n",
     "                                                                                 year=year,\n",
     "                                                                                 month=month,\n",
     "                                                                                 day=day)\n",
-    "    filename = 'SMAP_L3_SM_P_{year}{month:02}{day:02}_R14010_001.h5'.format(year=year, \n",
+    "    filename = 'SMAP_L3_SM_P_{year}{month:02}{day:02}_R19240_001.h5'.format(year=year, \n",
     "                                                                            month=month, \n",
     "                                                                            day=day)\n",
     "\n",


### PR DESCRIPTION
Update to SPL3SMP Major Version 9 (implemented 2023-12-04) and associated CRID, allowing access to data spanning 2015-03-31 to present.